### PR TITLE
[REVIEW] Fix feature_names_in_ estimator error 

### DIFF
--- a/tests/preprocessing/test_data.py
+++ b/tests/preprocessing/test_data.py
@@ -65,6 +65,8 @@ class TestStandardScaler:
         a = dpp.StandardScaler()
         b = spp.StandardScaler()
 
+        exclude = {"n_samples_seen_", "feature_names_in_"}
+
         assert_estimator_equal(
             a.fit(dask_df.values),
             a.fit(dask_df),
@@ -73,25 +75,25 @@ class TestStandardScaler:
         assert_estimator_equal(
             a.fit(dask_df),
             b.fit(pandas_df),
-            exclude=["n_samples_seen_", "feature_names_in_"],
+            exclude=exclude,
         )
 
         assert_estimator_equal(
             a.fit(dask_df.values),
             b.fit(pandas_df),
-            exclude=["n_samples_seen_", "feature_names_in_"],
+            exclude=exclude,
         )
 
         assert_estimator_equal(
             a.fit(dask_df),
             b.fit(pandas_df.values),
-            exclude=["n_samples_seen_", "feature_names_in_"],
+            exclude=exclude,
         )
 
         assert_estimator_equal(
             a.fit(dask_df.values),
             b.fit(pandas_df.values),
-            exclude=["n_samples_seen_", "feature_names_in_"],
+            exclude=exclude,
         )
 
     def test_inverse_transform(self):
@@ -526,7 +528,7 @@ class TestPolynomialFeatures:
         a = dpp.PolynomialFeatures()
         b = spp.PolynomialFeatures()
 
-        exclude = {"n_input_features_"}
+        exclude = {"n_input_features_", "feature_names_in_"}
 
         assert_estimator_equal(a.fit(df), a.fit(df.compute()), exclude=exclude)
         assert_estimator_equal(a.fit(df), a.fit(df.compute().values), exclude=exclude)

--- a/tests/preprocessing/test_data.py
+++ b/tests/preprocessing/test_data.py
@@ -66,23 +66,32 @@ class TestStandardScaler:
         b = spp.StandardScaler()
 
         assert_estimator_equal(
-            a.fit(dask_df.values), a.fit(dask_df),
+            a.fit(dask_df.values),
+            a.fit(dask_df),
         )
 
         assert_estimator_equal(
-            a.fit(dask_df), b.fit(pandas_df), exclude="n_samples_seen_"
+            a.fit(dask_df),
+            b.fit(pandas_df),
+            exclude=["n_samples_seen_", "feature_names_in_"],
         )
 
         assert_estimator_equal(
-            a.fit(dask_df.values), b.fit(pandas_df), exclude="n_samples_seen_"
+            a.fit(dask_df.values),
+            b.fit(pandas_df),
+            exclude=["n_samples_seen_", "feature_names_in_"],
         )
 
         assert_estimator_equal(
-            a.fit(dask_df), b.fit(pandas_df.values), exclude="n_samples_seen_"
+            a.fit(dask_df),
+            b.fit(pandas_df.values),
+            exclude=["n_samples_seen_", "feature_names_in_"],
         )
 
         assert_estimator_equal(
-            a.fit(dask_df.values), b.fit(pandas_df.values), exclude="n_samples_seen_"
+            a.fit(dask_df.values),
+            b.fit(pandas_df.values),
+            exclude=["n_samples_seen_", "feature_names_in_"],
         )
 
     def test_inverse_transform(self):

--- a/tests/preprocessing/test_data.py
+++ b/tests/preprocessing/test_data.py
@@ -66,14 +66,11 @@ class TestStandardScaler:
         b = spp.StandardScaler()
 
         assert_estimator_equal(
-            a.fit(dask_df.values),
-            a.fit(dask_df),
+            a.fit(dask_df.values), a.fit(dask_df),
         )
 
         assert_estimator_equal(
-            a.fit(dask_df),
-            b.fit(pandas_df),
-            exclude="n_samples_seen_",
+            a.fit(dask_df), b.fit(pandas_df), exclude="n_samples_seen_",
         )
 
         assert_estimator_equal(
@@ -89,9 +86,7 @@ class TestStandardScaler:
         )
 
         assert_estimator_equal(
-            a.fit(dask_df.values),
-            b.fit(pandas_df.values),
-            exclude="n_samples_seen_",
+            a.fit(dask_df.values), b.fit(pandas_df.values), exclude="n_samples_seen_",
         )
 
     def test_inverse_transform(self):

--- a/tests/preprocessing/test_data.py
+++ b/tests/preprocessing/test_data.py
@@ -65,8 +65,6 @@ class TestStandardScaler:
         a = dpp.StandardScaler()
         b = spp.StandardScaler()
 
-        exclude = {"n_samples_seen_", "feature_names_in_"}
-
         assert_estimator_equal(
             a.fit(dask_df.values),
             a.fit(dask_df),
@@ -75,25 +73,25 @@ class TestStandardScaler:
         assert_estimator_equal(
             a.fit(dask_df),
             b.fit(pandas_df),
-            exclude=exclude,
+            exclude="n_samples_seen_",
         )
 
         assert_estimator_equal(
             a.fit(dask_df.values),
             b.fit(pandas_df),
-            exclude=exclude,
+            exclude={"n_samples_seen_", "feature_names_in_"},
         )
 
         assert_estimator_equal(
             a.fit(dask_df),
             b.fit(pandas_df.values),
-            exclude=exclude,
+            exclude={"n_samples_seen_", "feature_names_in_"},
         )
 
         assert_estimator_equal(
             a.fit(dask_df.values),
             b.fit(pandas_df.values),
-            exclude=exclude,
+            exclude="n_samples_seen_",
         )
 
     def test_inverse_transform(self):
@@ -528,15 +526,25 @@ class TestPolynomialFeatures:
         a = dpp.PolynomialFeatures()
         b = spp.PolynomialFeatures()
 
-        exclude = {"n_input_features_", "feature_names_in_"}
-
-        assert_estimator_equal(a.fit(df), a.fit(df.compute()), exclude=exclude)
-        assert_estimator_equal(a.fit(df), a.fit(df.compute().values), exclude=exclude)
         assert_estimator_equal(
-            a.fit(df.values), a.fit(df.compute().values), exclude=exclude
+            a.fit(df), a.fit(df.compute()), exclude={"n_input_features_"}
         )
-        assert_estimator_equal(a.fit(df), b.fit(df.compute()), exclude=exclude)
-        assert_estimator_equal(a.fit(df), b.fit(df.compute().values), exclude=exclude)
+        assert_estimator_equal(
+            a.fit(df),
+            a.fit(df.compute().values),
+            exclude={"n_input_features_", "feature_names_in_"},
+        )
+        assert_estimator_equal(
+            a.fit(df.values), a.fit(df.compute().values), exclude={"n_input_features_"}
+        )
+        assert_estimator_equal(
+            a.fit(df), b.fit(df.compute()), exclude={"n_input_features_"}
+        )
+        assert_estimator_equal(
+            a.fit(df),
+            b.fit(df.compute().values),
+            exclude={"n_input_features_", "feature_names_in_"},
+        )
 
     def test_array_transform(self):
         a = dpp.PolynomialFeatures()


### PR DESCRIPTION
This PR fixes the CI failures at  [link](https://github.com/dask/dask-ml/pull/873) related to `sckit-lean=1.0.1` introduced by https://github.com/scikit-learn/scikit-learn/pull/21389   .



See comment at https://github.com/dask/dask-ml/pull/873#issuecomment-955782464   on issue https://github.com/dask/dask-ml/pull/873  

TODO:
- [x] Verify that everything passes locally with this PR and all the gen_cluster changes  . 

- [x] Verify CI success (See link https://github.com/VibhuJawa/dask-ml/runs/4062400439) 